### PR TITLE
Various Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0]
 
+### Changed
+
+* Allow expansion of URL even though values for paging are missing (are handled automatically by assemblers)
+
 ### Fixed
 
 * Correctly process MultiValueMaps in expand() methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0]
+
+### Fixed
+
+* Correctly process MultiValueMaps in expand() methods
+* Assemblers correctly build empty list wrappers if no list was provided
+
 ## [0.17.0]
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=de.kamillionlabs
 name=hateoflux
-version=0.17.0
+version=0.18.0

--- a/src/main/java/de/kamillionlabs/hateoflux/assembler/EmbeddingHalWrapperAssembler.java
+++ b/src/main/java/de/kamillionlabs/hateoflux/assembler/EmbeddingHalWrapperAssembler.java
@@ -67,7 +67,6 @@ public non-sealed interface EmbeddingHalWrapperAssembler<ResourceT, EmbeddedT> e
         SealedResourceListAssemblerModule<ResourceT, EmbeddedT>,
         SealedEmbeddedLinkAssemblerModule<EmbeddedT> {
 
-
     /**
      * Wraps a list of main resources with their corresponding embedded resources in a {@link HalListWrapper},
      * optionally
@@ -98,8 +97,14 @@ public non-sealed interface EmbeddingHalWrapperAssembler<ResourceT, EmbeddedT> e
                             return wrapInResourceWrapper(resource, embedded, exchange);
                         }).toList();
 
-        HalListWrapper<ResourceT, EmbeddedT> result = HalListWrapper.wrap(listOfWrappedResourcesWithEmbedded)
-                .withLinks(buildLinksForResourceList(pageInfo, sortCriteria, exchange));
+        HalListWrapper<ResourceT, EmbeddedT> result;
+
+        if (listOfWrappedResourcesWithEmbedded.isEmpty()) {
+            result = HalListWrapper.empty(getResourceTClass());
+        } else {
+            result = HalListWrapper.wrap(listOfWrappedResourcesWithEmbedded);
+        }
+        result.withLinks(buildLinksForResourceList(pageInfo, sortCriteria, exchange));
 
         if (pageInfo == null) {
             return result;

--- a/src/main/java/de/kamillionlabs/hateoflux/assembler/FlatHalWrapperAssembler.java
+++ b/src/main/java/de/kamillionlabs/hateoflux/assembler/FlatHalWrapperAssembler.java
@@ -116,8 +116,7 @@ public non-sealed interface FlatHalWrapperAssembler<ResourceT> extends
 
     /**
      * Wraps a list of resources into a {@link HalListWrapper}, optionally including pagination information, and
-     * enhances
-     * them with hypermedia links as defined by the assembler.
+     * enhances them with hypermedia links as defined by the assembler.
      *
      * @param resourcesToWrap
      *         the list of resources to be wrapped
@@ -142,8 +141,15 @@ public non-sealed interface FlatHalWrapperAssembler<ResourceT> extends
                         .map(resource -> wrapInResourceWrapper(resource, exchange))
                         .toList();
 
-        HalListWrapper<ResourceT, Void> result = HalListWrapper.wrap(listOfWrappedResources)
-                .withLinks(buildLinksForResourceList(pageInfo, sortCriteria, exchange));
+        HalListWrapper<ResourceT, Void> result;
+
+        if (listOfWrappedResources.isEmpty()) {
+            result = HalListWrapper.empty(getResourceTClass());
+        } else {
+            result = HalListWrapper.wrap(listOfWrappedResources);
+        }
+
+        result.withLinks(buildLinksForResourceList(pageInfo, sortCriteria, exchange));
 
         if (pageInfo == null) {
             return result;

--- a/src/main/java/de/kamillionlabs/hateoflux/assembler/SealedResourceListAssemblerModule.java
+++ b/src/main/java/de/kamillionlabs/hateoflux/assembler/SealedResourceListAssemblerModule.java
@@ -46,7 +46,7 @@ public sealed interface SealedResourceListAssemblerModule<ResourceT, EmbeddedT> 
      * type erasure removes generic type information at runtime. By implementing this method, the class type
      * of {@code ResourceT} becomes accessible. An implementation is as simple as:
      * <blockquote><pre>
-     * public Class<Book> getResourceTClass() {
+     * public Class&lt;Book&gt; getResourceTClass() {
      *     return Book.class;
      * }
      * </pre></blockquote>

--- a/src/main/java/de/kamillionlabs/hateoflux/assembler/SealedResourceListAssemblerModule.java
+++ b/src/main/java/de/kamillionlabs/hateoflux/assembler/SealedResourceListAssemblerModule.java
@@ -41,6 +41,20 @@ import java.util.List;
 public sealed interface SealedResourceListAssemblerModule<ResourceT, EmbeddedT> permits
         FlatHalWrapperAssembler, EmbeddingHalWrapperAssembler {
 
+    /**
+     * Specifies the class type of {@code ResourceT} that the assembler builds. This method is required because
+     * type erasure removes generic type information at runtime. By implementing this method, the class type
+     * of {@code ResourceT} becomes accessible. An implementation is as simple as:
+     * <blockquote><pre>
+     * public Class<Book> getResourceTClass() {
+     *     return Book.class;
+     * }
+     * </pre></blockquote>
+     *
+     * @return the class type of {@code ResourceT}
+     */
+    Class<ResourceT> getResourceTClass();
+
 
     /**
      * Creates an empty {@link HalListWrapper} including hypermedia links applicable to the entire list.

--- a/src/main/java/de/kamillionlabs/hateoflux/linkbuilder/SpringControllerLinkBuilder.java
+++ b/src/main/java/de/kamillionlabs/hateoflux/linkbuilder/SpringControllerLinkBuilder.java
@@ -63,7 +63,7 @@ public class SpringControllerLinkBuilder {
      * <p>
      * Given the following class:
      * <blockquote><pre>
-     * _@Controller
+     * _@Controller;
      * _@RequestMapping("/user")
      * public class UserController {
      *

--- a/src/main/java/de/kamillionlabs/hateoflux/linkbuilder/UriExpander.java
+++ b/src/main/java/de/kamillionlabs/hateoflux/linkbuilder/UriExpander.java
@@ -426,10 +426,10 @@ public class UriExpander {
 
         for (var parameterName : parameterNamesToTest) {
             Object parameterValue = parameters.get(parameterName);
-            if (parameterValue instanceof Collection<?>) {
-                if (!uriTemplateData.isExplodedQueryParameter(parameterName)) {
+            if (parameterValue instanceof Collection<?> parameterValueAsCollection) {
+                if (!uriTemplateData.isExplodedQueryParameter(parameterName) && parameterValueAsCollection.size() > 1) {
                     throw new IllegalArgumentException(format(
-                            "Detected a collection as value for a parameter, but parameter was not exploded in " +
+                            "Detected a collection of values for a parameter, but parameter was not exploded in " +
                                     "template (asterisk after parameter name e.g. {?var*}). " +
                                     "Template was '%s', parameters were %s", originalUriTemplate, parameters
                     ));

--- a/src/main/java/de/kamillionlabs/hateoflux/linkbuilder/UriExpander.java
+++ b/src/main/java/de/kamillionlabs/hateoflux/linkbuilder/UriExpander.java
@@ -36,6 +36,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class UriExpander {
 
+    private static final Set<String> PAGING_QUERY_PARAMETER = Set.of("page", "sort", "size");
+
     private UriExpander() {
     }
 
@@ -417,7 +419,13 @@ public class UriExpander {
                             "Template was '%s', parameters were %s", originalUriTemplate, parameters));
         }
 
-        if (!parameterNamesToTest.isEmpty() && uriTemplateData.includesUnknownParameters(parameterNamesToTest)) {
+        // paging parameters are allowed to be "unknown" because they can be generated and are generally handled
+        // automatically
+        Set<String> parameterNamesExcludingPagingParameters = new HashSet<>(parameterNamesToTest);
+        parameterNamesExcludingPagingParameters.removeAll(PAGING_QUERY_PARAMETER);
+
+        if (!parameterNamesToTest.isEmpty()
+                && uriTemplateData.includesUnknownParameters(parameterNamesExcludingPagingParameters)) {
             throw new IllegalArgumentException(format(
                     "Unknown parameters provided for URI template expansion. " +
                             "Template was '%s', parameters were %s", originalUriTemplate, parameters));
@@ -457,6 +465,43 @@ public class UriExpander {
             }
         }
         return result;
+    }
+
+    /**
+     * Removes existing paging query parameters {@code page}, {@code size}, and {@code sort}. Any other query parameter
+     * is ignored. If as a result the URI has no query paramters anymore, the '?' is removed.
+     *
+     * @param inputUrl
+     *         input URL to remove paging parameters from
+     * @return sanitized URL
+     */
+    public static String removePagingParameters(String inputUrl) {
+        // Split the inputUrl into base URL and query string
+        if (inputUrl == null || inputUrl.isEmpty()) {
+            return inputUrl;
+        }
+
+        int idx = inputUrl.indexOf('?');
+        if (idx == -1) {
+            // No query parameters
+            return inputUrl;
+        }
+        String baseUrl = inputUrl.substring(0, idx);
+        String query = inputUrl.substring(idx + 1);
+
+        // Regex pattern to match 'page', 'size', and 'sort' parameters
+        String pattern = "(^|&)(page|size|sort)(=[^&]*)?(?=&|$)";
+        query = query.replaceAll(pattern, "");
+
+        // Remove any leading or trailing '&' characters
+        query = query.replaceAll("^&+", "").replaceAll("&+$", "");
+
+        // Build the output URL
+        if (query.isEmpty()) {
+            return baseUrl;
+        } else {
+            return baseUrl + "?" + query;
+        }
     }
 
 }

--- a/src/main/java/de/kamillionlabs/hateoflux/model/hal/HalListWrapper.java
+++ b/src/main/java/de/kamillionlabs/hateoflux/model/hal/HalListWrapper.java
@@ -177,4 +177,15 @@ public final class HalListWrapper<ResourceT, EmbeddedT>
     public String getNameOfResourceList() {
         return resourceList.getKey();
     }
+
+
+    /**
+     * Indicates whether the wrapper hold a non-empty list.
+     *
+     * @return {@code true} if list is non-empty; {@code false} otherwise
+     */
+    @JsonIgnore
+    public boolean isEmpty() {
+        return resourceList.getValue().isEmpty();
+    }
 }

--- a/src/main/java/de/kamillionlabs/hateoflux/model/link/Link.java
+++ b/src/main/java/de/kamillionlabs/hateoflux/model/link/Link.java
@@ -40,6 +40,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static de.kamillionlabs.hateoflux.linkbuilder.UriExpander.removePagingParameters;
 import static de.kamillionlabs.hateoflux.utility.ValidationMessageTemplates.valueNotAllowedToBeEmpty;
 
 /**
@@ -417,23 +418,25 @@ public class Link {
         Assert.isTrue(!isTemplated(), "Navigation links can only be derived if the href is not a template. " +
                 "Please expand the URI first.");
 
+        String sanitizedHref = removePagingParameters(href); // remove existing paging parameters if they exist
+
         int size = pagingInformation.size();
         int totalPages = pagingInformation.totalPages();
         int number = pagingInformation.number();
 
 
         List<Link> result = new ArrayList<>();
-        result.add(createLinkForPage(IanaRelation.SELF, number, size, sortCriteria));
+        result.add(createLinkForPage(sanitizedHref, IanaRelation.SELF, number, size, sortCriteria));
 
         if (totalPages > 0) {
             if (number > 0) {
-                result.add(createLinkForPage(IanaRelation.FIRST, 0, size, sortCriteria));
-                result.add(createLinkForPage(IanaRelation.PREV, number - 1, size, sortCriteria));
+                result.add(createLinkForPage(sanitizedHref, IanaRelation.FIRST, 0, size, sortCriteria));
+                result.add(createLinkForPage(sanitizedHref, IanaRelation.PREV, number - 1, size, sortCriteria));
             }
 
             if (number < totalPages - 1) {
-                result.add(createLinkForPage(IanaRelation.NEXT, number + 1, size, sortCriteria));
-                result.add(createLinkForPage(IanaRelation.LAST, totalPages - 1, size, sortCriteria));
+                result.add(createLinkForPage(sanitizedHref, IanaRelation.NEXT, number + 1, size, sortCriteria));
+                result.add(createLinkForPage(sanitizedHref, IanaRelation.LAST, totalPages - 1, size, sortCriteria));
             }
         }
         return result;
@@ -463,7 +466,8 @@ public class Link {
         return deriveNavigationLinks(pagingInformation, sortCriteriaAsArray);
     }
 
-    private Link createLinkForPage(IanaRelation relType, int pageNumber, int size, SortCriteria... sortingCriteria) {
+    private Link createLinkForPage(String href, IanaRelation relType, int pageNumber, int size,
+                                   SortCriteria... sortingCriteria) {
         Map<String, Object> parameters = new LinkedHashMap<>();
         parameters.put("page", pageNumber);
         parameters.put("size", size);

--- a/src/main/java/de/kamillionlabs/hateoflux/model/link/Link.java
+++ b/src/main/java/de/kamillionlabs/hateoflux/model/link/Link.java
@@ -589,7 +589,7 @@ public class Link {
      *         specifies whether the collection should be rendered as composite (true) or non-composite (false)
      * @return the expanded or original URI if expansion is not applicable
      */
-    public Link expand(Map<String, Object> parameters, boolean collectionRenderedAsComposite) {
+    public Link expand(Map<String, ?> parameters, boolean collectionRenderedAsComposite) {
         String newHref = UriExpander.expand(this.href, parameters, collectionRenderedAsComposite);
         return this.withHref(newHref);
     }
@@ -602,7 +602,7 @@ public class Link {
      *         to expand in templated href
      * @return the expanded or original URI if expansion is not applicable
      */
-    public Link expand(Map<String, Object> parameters) {
+    public Link expand(Map<String, ?> parameters) {
         return expand(parameters, false);
     }
 }

--- a/src/main/java/de/kamillionlabs/hateoflux/utility/PairList.java
+++ b/src/main/java/de/kamillionlabs/hateoflux/utility/PairList.java
@@ -26,6 +26,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import static de.kamillionlabs.hateoflux.utility.ValidationMessageTemplates.valueNotAllowedToBeNull;
+
 /**
  * A list implementation that stores pairs of values.
  *
@@ -147,8 +149,8 @@ public class PairList<LeftT, RightT> extends LinkedList<Pair<LeftT, RightT>> {
      *         if the lists are null or of different sizes
      */
     public static <LeftT, RightT> PairList<LeftT, RightT> of(List<LeftT> lefts, List<RightT> rights) {
-        Assert.notNull(lefts, "lefts must not be null");
-        Assert.notNull(rights, "rights must not be null");
+        Assert.notNull(lefts, valueNotAllowedToBeNull("lefts"));
+        Assert.notNull(rights, valueNotAllowedToBeNull("rights"));
         Assert.isTrue(lefts.size() == rights.size(), "Different sizes in lefts and rights are not allowed");
 
         List<Pair<LeftT, RightT>> pairs = new LinkedList<>();

--- a/src/test/java/de/kamillionlabs/hateoflux/assembler/EmbeddingHalWrapperAssemblerTest.java
+++ b/src/test/java/de/kamillionlabs/hateoflux/assembler/EmbeddingHalWrapperAssemblerTest.java
@@ -24,6 +24,11 @@ class EmbeddingHalWrapperAssemblerTest {
     static class AssemblerUnderTest implements EmbeddingHalWrapperAssembler<Book, Author> {
 
         @Override
+        public Class<Book> getResourceTClass() {
+            return Book.class;
+        }
+
+        @Override
         public Link buildSelfLinkForResourceList(ServerWebExchange exchange) {
             return Link.of("resource-list/self/link");
         }
@@ -47,6 +52,7 @@ class EmbeddingHalWrapperAssemblerTest {
     // -----------------------------------------------------------------------------------------------------------------
 
     private final AssemblerUnderTest assemblerUnderTest = new AssemblerUnderTest();
+
 
     @Test
     public void givenResourceWithEmbedded_whenWrapInResourceWrapper_thenAllFieldsAreFilled() {
@@ -246,6 +252,7 @@ class EmbeddingHalWrapperAssemblerTest {
 
         //Rudimentary testing (rest is tested elsewhere)
         assertThat(actualWrapper).isNotNull();
+        assertThat(actualWrapper.isEmpty()).isEqualTo(false);
         List<HalResourceWrapper<Book, Author>> actualResourceList = actualWrapper.getResourceList();
         assertThat(actualResourceList).isNotNull();
         HalEmbeddedWrapper<Author> actualEmbedded = actualResourceList.get(0).getRequiredEmbedded().get(0);
@@ -278,5 +285,18 @@ class EmbeddingHalWrapperAssemblerTest {
 
         //THEN
         assertThat(actualWrapper.getNameOfResourceList()).isEqualTo("customBooks");
+    }
+
+    @Test
+    public void givenEmptyPairs_whenWrapInListWrapper_thenNoException() {
+        //GIVEN
+        HalListWrapper<Book, Author> emptyWrapper = assemblerUnderTest.wrapInListWrapper(new PairList<>(), null);
+
+        //THEN
+        assertThat(emptyWrapper).isNotNull();
+        assertThat(emptyWrapper.isEmpty()).isEqualTo(true);
+        assertThat(emptyWrapper.getNameOfResourceList()).isEqualTo("customBooks");
+        assertThat(emptyWrapper.getLinks()).hasSize(1);
+        assertThat(emptyWrapper.getLinks().get(0).getHref()).isEqualTo("resource-list/self/link");
     }
 }

--- a/src/test/java/de/kamillionlabs/hateoflux/assembler/FlatHalWrapperAssemblerTest.java
+++ b/src/test/java/de/kamillionlabs/hateoflux/assembler/FlatHalWrapperAssemblerTest.java
@@ -21,6 +21,11 @@ class FlatHalWrapperAssemblerTest {
     static class AssemblerUnderTest implements FlatHalWrapperAssembler<Book> {
 
         @Override
+        public Class<Book> getResourceTClass() {
+            return Book.class;
+        }
+
+        @Override
         public Link buildSelfLinkForResourceList(ServerWebExchange exchange) {
             return Link.of("resource-list/self/link");
         }
@@ -33,6 +38,7 @@ class FlatHalWrapperAssemblerTest {
 
     // -----------------------------------------------------------------------------------------------------------------
     private final AssemblerUnderTest assemblerUnderTest = new AssemblerUnderTest();
+
 
     @Test
     public void givenResourceWithEmbedded_wrapInResourceWrapper_thenAllFieldsAreFilled() {
@@ -165,6 +171,19 @@ class FlatHalWrapperAssemblerTest {
 
         //THEN
         assertThat(actualWrapper.getNameOfResourceList()).isEqualTo("customBooks");
+    }
+
+    @Test
+    public void givenEmptyPairs_whenWrapInListWrapper_thenNoException() {
+        //GIVEN & WHEN
+        HalListWrapper<Book, Void> emptyWrapper = assemblerUnderTest.wrapInListWrapper(List.of(), null);
+
+        //THEN
+        assertThat(emptyWrapper).isNotNull();
+        assertThat(emptyWrapper.isEmpty()).isEqualTo(true);
+        assertThat(emptyWrapper.getNameOfResourceList()).isEqualTo("customBooks");
+        assertThat(emptyWrapper.getLinks()).hasSize(1);
+        assertThat(emptyWrapper.getLinks().get(0).getHref()).isEqualTo("resource-list/self/link");
     }
 
 }

--- a/src/test/java/de/kamillionlabs/hateoflux/assembler/ReactiveEmbeddingHalWrapperAssemblerTest.java
+++ b/src/test/java/de/kamillionlabs/hateoflux/assembler/ReactiveEmbeddingHalWrapperAssemblerTest.java
@@ -24,6 +24,11 @@ class ReactiveEmbeddingHalWrapperAssemblerTest {
     static class AssemblerUnderTest implements ReactiveEmbeddingHalWrapperAssembler<Book, Author> {
 
         @Override
+        public Class<Book> getResourceTClass() {
+            return Book.class;
+        }
+
+        @Override
         public Link buildSelfLinkForResourceList(ServerWebExchange exchange) {
             return Link.of("reactive/resource-list/self/link");
         }

--- a/src/test/java/de/kamillionlabs/hateoflux/assembler/ReactiveFlatHalWrapperAssemblerTest.java
+++ b/src/test/java/de/kamillionlabs/hateoflux/assembler/ReactiveFlatHalWrapperAssemblerTest.java
@@ -21,6 +21,11 @@ class ReactiveFlatHalWrapperAssemblerTest {
     static class AssemblerUnderTest implements ReactiveFlatHalWrapperAssembler<Book> {
 
         @Override
+        public Class<Book> getResourceTClass() {
+            return Book.class;
+        }
+
+        @Override
         public Link buildSelfLinkForResourceList(ServerWebExchange exchange) {
             return Link.of("reactive/resource-list/self/link");
         }

--- a/src/test/java/de/kamillionlabs/hateoflux/linkbuilder/UriExpanderTest.java
+++ b/src/test/java/de/kamillionlabs/hateoflux/linkbuilder/UriExpanderTest.java
@@ -17,6 +17,50 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 class UriExpanderTest {
+    @ParameterizedTest
+    @CsvSource({ // This method under test removes the 3 query parameters page, size and sort.
+
+            // No query parameters
+            "'customer/34/orders', 'customer/34/orders'",
+
+            // Only other query parameter available
+            "'orders?userId=34', 'orders?userId=34'",
+
+            // No query parameters
+            "'customer/34/orders', 'customer/34/orders'",
+
+            // just sort present
+            "'customer/34/orders?sort=date,desc', 'customer/34/orders'",
+
+            // just size present
+            "'customer/34/orders?size=0', 'customer/34/orders'",
+
+            // just page present
+            "'customer/34/orders?page=0', 'customer/34/orders'",
+
+            // all the 3 present
+            "'customer/34/orders?page=0&size=20&sort=date,desc', 'customer/34/orders'",
+
+            // all the 3, sort twice and an extra query parameter at the front
+            "'orders?userId=34&page=0&size=20&sort=date,desc&sort=total,asc', 'orders?userId=34'",
+
+            // all the 3 and an extra query parameter at the front
+            "'orders?userId=34&page=0&size=20&sort=date,desc', 'orders?userId=34'",
+
+            // all the 3 and an extra query parameter at the back
+            "'orders?page=0&size=20&sort=date,desc&userId=34', 'orders?userId=34'",
+
+            // all the 3 and an extra query parameter in the middle
+            "'orders?page=0&size=20&userId=34&sort=date,desc', 'orders?userId=34'",
+
+            // all the 3 and an extra query parameter in the middle and with a full base URL
+            "'www.example.com/orders?page=0&size=20&userId=34&sort=date,desc', 'www.example.com/orders?userId=34'"
+    })
+    public void givenInputUrl_whenRemovePagingParameters_thenOutputUrl(String inputUrl, String expectedOutputUrl) {
+        String outputUrl = UriExpander.removePagingParameters(inputUrl);
+        assertThat(outputUrl).isEqualTo(expectedOutputUrl);
+    }
+
 
     @ParameterizedTest
     @CsvSource(delimiter = ';', value = {

--- a/src/test/java/de/kamillionlabs/hateoflux/linkbuilder/UriExpanderTest.java
+++ b/src/test/java/de/kamillionlabs/hateoflux/linkbuilder/UriExpanderTest.java
@@ -1,9 +1,12 @@
 package de.kamillionlabs.hateoflux.linkbuilder;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -191,13 +194,28 @@ class UriExpanderTest {
     }
 
     @Test
+    void givenExplodedQueryParameterWithSingleValue_whenExpandWithMap_thenCorrectUri() {
+        //GIVEN
+        String template = "/users{?keyWords*,limit}";
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("keyWords", List.of("active"));
+        map.put("limit", 10);
+
+        //WHEN
+        String actual = UriExpander.expand(template, map);
+
+        //THEN
+        assertThat(actual).isEqualTo("/users?keyWords=active&limit=10");
+    }
+
+    @Test
     void givenNotExplodedQueryParameter_whenExpandWithMap_thenThrowException() {
         //GIVEN
         String template = "/users{?keyWords}";
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("keyWords", List.of("active", "blue", "positive"));
         assertThatThrownBy(() -> UriExpander.expand(template, map)).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Detected a collection as value for a parameter, but parameter was not exploded in " +
+                .hasMessage("Detected a collection of values for a parameter, but parameter was not exploded in " +
                         "template (asterisk after parameter name e.g. {?var*}). " +
                         "Template was '/users{?keyWords}', parameters were {keyWords=[active, blue, positive]}");
     }
@@ -237,6 +255,20 @@ class UriExpanderTest {
         assertThatThrownBy(() -> UriExpander.expand(template, Map.of("key1", "value1", "key2", "value2")))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unknown parameters provided for URI template expansion.");
+    }
+
+
+    @Test
+    public void givenMultiValueMap_whenExpandWithMultiValueMap_thenPlaceholdersCorrectlySet() {
+        // GIVEN
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add("someId", "54");
+
+        // WHEN
+        String expanded = UriExpander.expand("http://example.com{?someId}", queryParams);
+
+        //THEN
+        Assertions.assertThat(expanded).isEqualTo("http://example.com?someId=54");
     }
 
 

--- a/src/test/java/de/kamillionlabs/hateoflux/model/LinkTest.java
+++ b/src/test/java/de/kamillionlabs/hateoflux/model/LinkTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import java.util.List;
 import java.util.Map;
@@ -228,6 +230,20 @@ class LinkTest {
         Link link = Link.of("http://example.com/{someId}");
         Link actual = link.expand(Map.of("someId", 54));
         assertThat(actual.getHref()).isEqualTo("http://example.com/54");
+    }
+
+    @Test
+    public void givenMultiValueMap_whenExpand_thenPlaceholdersCorrectlySet() {
+        // GIVEN
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add("someId", "54");
+
+        // WHEN
+        Link link = Link.of("http://example.com{?someId}")
+                .expand(queryParams);
+
+        //THEN
+        assertThat(link.getHref()).isEqualTo("http://example.com?someId=54");
     }
 
     @ParameterizedTest

--- a/src/test/java/de/kamillionlabs/hateoflux/model/LinkTest.java
+++ b/src/test/java/de/kamillionlabs/hateoflux/model/LinkTest.java
@@ -78,12 +78,32 @@ class LinkTest {
         assertThat(findLinkByRel(navigationLinks, "last")).isNotNull();
     }
 
+
     // Helper method to find a link by its rel
     private Link findLinkByRel(List<Link> links, String rel) {
         return links.stream()
                 .filter(l -> rel.equals(l.getLinkRelation().getRelation()))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("Expected link with rel '" + rel + "' not found"));
+    }
+
+    @Test
+    void givenUrlWithPagingInfoAlready_whenDeriveNavigationLinks_thenHrefDoNotIncludeDoubleQueryParams() {
+        // GIVEN
+        HalPageInfo pageInfo = new HalPageInfo(2, 2L, 1, 0); // Single page
+        // already contains paging though it is different
+        Link link = Link.of("https://example.com/resource?page=1&size=10&sort=age,desc");
+        SortCriteria sortCriteria1 = new SortCriteria("name", SortDirection.ASCENDING);
+
+        // WHEN
+        List<Link> navigationLinks = link.deriveNavigationLinks(pageInfo, sortCriteria1);
+
+        // THEN
+        Link selfLink = findLinkByRel(navigationLinks, "self");
+
+        // Assertions
+        assertThat(selfLink.getHref())
+                .isEqualTo("https://example.com/resource?page=0&size=2&sort=name,asc");
     }
 
     @ParameterizedTest

--- a/src/test/java/de/kamillionlabs/hateoflux/model/hal/SerializationTest.java
+++ b/src/test/java/de/kamillionlabs/hateoflux/model/hal/SerializationTest.java
@@ -273,4 +273,6 @@ public class SerializationTest {
                   }
                 """, actualJson, NON_EXTENSIBLE);
     }
+
+
 }

--- a/src/test/java/de/kamillionlabs/hateoflux/utility/PairListTest.java
+++ b/src/test/java/de/kamillionlabs/hateoflux/utility/PairListTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 public class PairListTest {
 
@@ -292,5 +293,29 @@ public class PairListTest {
         assertThat(pairList.getRight(8)).isEqualTo(9);
         assertThat(pairList.getLeft(9)).isEqualTo("ten");
         assertThat(pairList.getRight(9)).isEqualTo(10);
+    }
+
+
+    @Test
+    void givenInputListOfDifferentSizes_WhenOfMethodCalled_thenThrowException() {
+        assertThatThrownBy(() -> PairList.of(List.of(1, 2), List.of("1")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Different sizes in lefts and rights are not allowed");
+
+    }
+
+    @Test
+    void givenInputListRightIsNull_WhenOfMethodCalled_thenThrowException() {
+        assertThatThrownBy(() -> PairList.of(List.of(1, 2), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rights is not allowed to be null");
+    }
+
+    @Test
+    void givenInputListLeftIsNull_WhenOfMethodCalled_thenThrowException() {
+        assertThatThrownBy(() -> PairList.of(null, List.of("1")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("lefts is not allowed to be null");
+
     }
 }


### PR DESCRIPTION
Fixes:
* Correctly process MultiValueMaps in expand() methods
* Assemblers correctly build empty list wrappers if no list was provided

Change:
* Allow expansion of URL even though values for paging are missing (are handled automatically by assemblers)